### PR TITLE
docs: removal of the 'pick' package installation instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,9 @@ Navigate into the cloned directory
 cd autoactivator
 ```
 
-Install the 'pick' package using pip and run the installation script
+Run the installation script
 
 ```bash
-pip install pick
 python3 install.py
 ```
 


### PR DESCRIPTION
As the 'Pick' package was recently replaced by an in-house function that does the same job and with a Python built-in package called 'curses'